### PR TITLE
Menu fix desktop

### DIFF
--- a/public/styles/drop.css
+++ b/public/styles/drop.css
@@ -69,7 +69,7 @@
 
 @media (min-width: 1024px) {
   .nav-content {
-    padding-top: 30%;
+    padding-top: 15%;
   }
 }
 
@@ -100,16 +100,24 @@
 
 
   /* desktop MENU BAR  */
-@media (min-width: 1024px) {
-  .menu-bar {
-    margin-top: -18.75rem;
-    margin-right: 1.25rem;
-    justify-content: flex-end;
-    padding: 0.8rem 2rem;
-    gap: 1.5rem; 
-
+  @media (min-width: 1024px) {
+    .menu-bar {
+      position: absolute;
+      top: 0.5rem; 
+      right: 2rem;
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      gap: 1.5rem;
+      padding: 0.8rem 1rem;
+      z-index: 20;
+    }
+  
+    .nav-content {
+      position: relative; 
+    }
   }
-}
+  
 
 /*  BUTTONS  */
 .tickets-btn {
@@ -174,19 +182,39 @@
   padding-bottom: 1.5rem;
 }
 
+.nav-columns .column h3 a {
+  text-align: center;
+  display: inline-block; 
+  color: inherit;
+  text-decoration: none;
+}
+
+
+
+.column h3 a span.arabic {
+  margin-bottom: 0.7rem; 
+  display: block;
+}
+
+
   /* desktop NAV COLUMNS  */
 
 @media (min-width: 1024px) {
-  .nav-columns {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    column-gap: 2.6rem;
-    padding: 1.5rem 0;
-    margin-top: 12.5rem; 
-    width: 100%;
-    border-bottom: 1px solid var(--color-black);
-  }
+    .nav-columns {
+      display: grid;
+      grid-template-columns: repeat(4, auto);
+      justify-content: start; 
+      column-gap: 2.6rem;
+      padding-left: 1.2rem; 
+      padding-right: 2rem;
+      padding-top: 12rem;
+      padding-bottom: 1.5rem;
+      margin-top: 0;
+      width: 100%;
+      border-bottom: 1px solid var(--color-black);
+    }
 }
+
 
 
 /* mobile COLUMN STYLING  */
@@ -209,21 +237,9 @@
   }
 }
 
-
-/*  COLUMN HEADINGS  */
-.column h3 {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: left; 
-  line-height: 1;
-
-}
-
 .column .arabic {
   font-family: var(--arabic-font);
-  font-size: 1.8rem;
+  font-size: 2rem;
   text-align: left; 
   font-weight: 800;
   direction: rtl;
@@ -233,7 +249,7 @@
 /* desktop */
 @media (max-width: 1024px) {
   .column .arabic {
-    font-size: 1.8rem;
+    font-size: 2.2rem;
     }
   }
 
@@ -241,24 +257,26 @@
 /* Mobile: standaard groot */
 .column .english {
   font-family: var(--font-en-bold); 
-  font-size: 2.2rem;  
+  font-size: 2.6rem;  
   text-align: left; 
   font-weight: 800; 
   white-space: nowrap;
   letter-spacing: 0.01em; 
+  
 }
 
 /* Desktop: kleiner maken */
 @media (min-width: 1024px) {
   .column .english {
-    font-size: 2.2rem;
+    font-size: 2.4rem;
     white-space: normal;
     white-space: nowrap;
+    display: inline-block;
+    text-align: center;
+  
 
   }
 }
-
-
 
 
 /*  mobile SUB LINKS  */
@@ -365,7 +383,7 @@
 #dropdown-menu {
   position: fixed;
   inset: 0;
-  background-color: #FFD900;
+  background-color: #FFE40A;
   z-index: 1000;
   overflow-y: auto;
   visibility: hidden;
@@ -437,6 +455,7 @@
   filter: blur(12px);
 }
 
+
 /* Hover: laat overlay zien en micro-animatie */
 .column:hover .hover-overlay {
   opacity: 1;
@@ -486,7 +505,6 @@
   transform: translate3d(0%, 0%, 0);
 }
 
-
 /* HOVER STYLING LINKS  */
  a:hover {
   transition: color 0.3s ease;
@@ -502,21 +520,17 @@
   transition: color 0.3s ease;
 }
 
-@media (max-width: 768px) {
-  .column .hover-overlay {
-    opacity: 0;
-    animation: none;
-    transform: none;
-    display: none;
-  }
 
-  .column:hover .hover-overlay {
-    opacity: 0;
-    animation: none;
-    transform: none;
-    display: none;
+@media (max-width: 768px) {
+    .column .hover-overlay,
+    .column:hover .hover-overlay {
+      opacity: 0;
+      animation: none;
+      transform: none;
+      display: none;
+    }
   }
-}
+  
 
 /*  ACCESSIBILITY  */
 .visually-hidden {
@@ -530,6 +544,10 @@
   white-space: nowrap;
   border: 0;
 }
+
+
+
+
 
 
 

--- a/public/styles/nav.css
+++ b/public/styles/nav.css
@@ -76,13 +76,15 @@
     .nav-links {
         list-style: none;
         display: flex;
-        flex-grow: 1;
-        justify-content: flex-start;
+        justify-content: flex-end; 
         gap: 1.4rem;
         font-weight: bold;
         font-size: var(--font-size-base);
         align-items: center;
-        margin-left: 270px;
+        padding-left: 11rem; 
+        max-width: 1400px;
+        width: 100%;
+        margin: 0 auto;
     }
 
     .nav-links a {
@@ -107,24 +109,23 @@
 
 
     /* TICKETS button */
-.highlight {
-    display: flex;
-    align-items: center;
-    list-style: none;
-    justify-content: center;
-    background-color: var(--hilight-color);
-    padding: 0.9rem 0.9rem;
-    font-size: var(--font-size-base);
-    font-family: var( --font-en-bold);
-    border: 1px solid var(--color-black);
-    width: auto;
-    height: auto;
-    text-transform: uppercase;
-    line-height: var(--line-height-heading);
-    margin-left: 1rem;
-}
+    .highlight {
+        display: flex;
+        align-items: center;
+        list-style: none;
+        justify-content: center;
+        background-color: var(--hilight-color);
+        padding: 0.9rem 0.9rem;
+        font-size: var(--font-size-base);
+        font-family: var( --font-en-bold);
+        border: 1px solid var(--color-black);
+        width: auto;
+        height: auto;
+        text-transform: uppercase;
+        line-height: var(--line-height-heading);
+    }
 
-.highlight:hover {
+    .highlight:hover {
     background-color: var(--color-black);
     color: var(--color-white);
 }

--- a/views/partials/dropdown.liquid
+++ b/views/partials/dropdown.liquid
@@ -46,7 +46,7 @@
           </svg>
           VENUES
         </a>
-        <span class="arabic">العربية</span>
+        <a href="/" class="arabic">العربية</a>
         <a href="#" class="close-btn">
           <svg fill="currentColor" height="18" viewBox="0 0 30 30" width="18" xmlns="http://www.w3.org/2000/svg">
             <path d="m20.7 10.8-1.5-1.5-4.2 4.3-4.2-4.3-1.5 1.5 4.3 4.2-4.3 4.2 1.5 1.5 4.2-4.3 4.2 4.3 1.5-1.5-4.3-4.2z"></path>

--- a/views/partials/dropdown.liquid
+++ b/views/partials/dropdown.liquid
@@ -55,44 +55,51 @@
         </a>
       </nav>
 
-
   <!-- Main navigation columns -->
-<section class="nav-columns">
-  <h2 class="visually-hidden">Explore Sections</h2>
-
-  <article class="column">
-    <div class="hover-overlay"></div>
-    <h3>
-      <span class="arabic">قـصــصــنـا</span>
-      <span class="english">STORIES</span>
-    </h3>
-  </article>
-
-  <article class="column">
-    <div class="hover-overlay"></div>
-    <h3>
-      <span class="arabic">الـفـعــالــيــات</span>
-      <span class="english">WHAT’S ON</span>
-    </h3>
-  </article>
-
-  <article class="column">
-    <div class="hover-overlay"></div>
-    <h3>
-      <span class="arabic">الــمـــقــتــنــيـات</span>
-      <span class="english">COLLECTIONS</span>
-    </h3>
-  </article>
-
-  <article class="column">
-    <div class="hover-overlay"></div>
-    <h3>
-      <span class="arabic">زيـــارة</span>
-      <span class="english">VISIT</span>
-    </h3>
-  </article>
-</section>
-
+  <section class="nav-columns">
+    <h2 class="visually-hidden">Explore Sections</h2>
+  
+    <article class="column">
+      <div class="hover-overlay"></div>
+      <h3>
+        <a href="/">
+        <span class="arabic">قـصــصــنـا</span>
+        <span class="english">STORIES</span>
+        </a>
+      </h3>
+    </article>
+  
+    <article class="column">
+      <div class="hover-overlay"></div>
+      <h3>
+        <a href="/">
+        <span class="arabic">الـفـعــالــيــات</span>
+        <span class="english">WHAT’S ON</span>
+        </a>
+      </h3>
+    </article>
+  
+    <article class="column">
+      <div class="hover-overlay"></div>
+      <h3>
+        <a href="/">
+        <span class="arabic">الــمـــقــتــنــيـات</span>
+        <span class="english">COLLECTIONS</span>
+        </a>
+      </h3>
+    </article>
+  
+    <article class="column">
+      <div class="hover-overlay"></div>
+      <h3>
+      <a href="/">
+        <span class="arabic">زيـــارة</span>
+        <span class="english">VISIT</span>
+      </a>
+      </h3>
+    </article>
+  </section>
+  
       
 
       <!-- Additional links -->


### PR DESCRIPTION
##  Wat is er veranderd in de commit?

- De navbar op desktop heeft nu een vaste positionering gekregen, zodat deze niet meer verschuift op grotere schermen.
- De **dropdown-menu** is gepositioneerd om te voorkomen dat deze naar beneden zakt op brede resoluties.
- Er zijn **`<a href>`-links** toegevoegd aan de dropdown-navigatie, zodat de kolommen klikbaar zijn.

##  Wat moet er gereviewd worden?

- Bekijk of de klikbare links in de dropdown goed werken.
- Ik heb dit getest op een monitor (groot scherm), voor het geval jullie niet met een tweede scherm werken.



---
![Scherm­afbeelding 2025-05-26 om 15 13 19 (2)](https://github.com/user-attachments/assets/92340e25-beca-49a6-b748-8e14e10b97ec)
![Scherm­afbeelding 2025-05-26 om 15 13 14 (2)](https://github.com/user-attachments/assets/30afa499-68ee-4a40-a6f0-1e44a98779aa)

